### PR TITLE
fix: モバイルでヒーローロゴのアスペクト比を維持

### DIFF
--- a/webPage/src/pages/index.vue
+++ b/webPage/src/pages/index.vue
@@ -593,7 +593,7 @@ ul, ol { list-style: none; }
     radial-gradient(circle at 50% 38%, rgba(112, 196, 235, .12), transparent 60%),
     #FCFEFF;
 }
-.hero__logo { height: 184px; width: auto; }
+.hero__logo { max-height: 184px; max-width: calc(100% - 2rem); width: auto; height: auto; }
 
 /* ===== main shell ===== */
 main {


### PR DESCRIPTION
横幅が足りない時、固定 height により横に潰れていたのを、
max-height/max-width で縦横比を保ったまま縮小するよう修正。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011pu37981k5QqVzB19ymUHe